### PR TITLE
Switch to Debian Stretch to Sidestep Broken Sid

### DIFF
--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -2,7 +2,8 @@
 # This is the main Dockerfile for the kclpy image.
 # Please avoid putting demo-only tools and
 # configuration in here.
-FROM openjdk:jre-slim as kclpy
+FROM openjdk:8-jre-slim-stretch as kclpy
+RUN java -version
 WORKDIR /srv
 RUN apt-get -qqy update \
  && apt-get -qqy install python3 \

--- a/context/exec-kcl
+++ b/context/exec-kcl
@@ -12,11 +12,9 @@ main() {
   echo 'and/or KCL_PROPERTIES_FILE in the environment.'
 
   ##
-  # --add-modules java.xml.bind to fix an error where JaxB is not found.
   # expand $KCL_EXTRA_ARGS so that users can inject extra arguments easily.
   # expand $KCL_PROPERTIES_FILE with sample.properties from kclpy as the default.
   exec java -cp "$(amazon_kclpy_helper.py --sample --print_classpath)" \
-            --add-modules java.xml.bind \
             $KCL_EXTRA_ARGS \
             com.amazonaws.services.kinesis.multilang.MultiLangDaemon \
             "${KCL_PROPERTIES_FILE:-sample.properties}"


### PR DESCRIPTION
Avoids the problem described in debuerreotype/docker-debian-artifacts#50.

Closes #2.